### PR TITLE
Add netem_rate and netem_limit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ Format for the options is the same as [tc-netem](https://man7.org/linux/man-page
     "loss": "0.3% 25%",
     "duplicate": "1%",
     "corrupt": "0.1%",
-    # Rate control using Netem 
+    # Bitrate control using Netem 
     "netem_rate": "256kbit",
-    # Rate control using TBF
+    "netem_limit": 3000,
+    # Bitrate control using TBF
     "rate": "256kbit",
     "buffer": 1600,
     "limit": 3000,

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If the host cannot download package from PyPI, you can use PyNetem (>=0.1.2) in 
 ```
 
 You can also use original command of `tc/netem`.
-For more information about `tc/netem`, you can click here: [netem](https://wiki.linuxfoundation.org/networking/netem)
+For more information about `tc/netem`, you can click here: [netem](https://man7.org/linux/man-pages/man8/tc-netem.8.html)
 
 It is recommended to use web mode, when you have several hosts to control, or you want to build a web page for easier usage.
 
@@ -37,8 +37,11 @@ There are 8 APIs:
 ```
 Post Body, if you set parameter `None` or `''`, the parameter will be ignored.
 
+Format for the options is the same as [tc-netem](https://man7.org/linux/man-pages/man8/tc-netem.8.html)'s and
+[tc-tbf](https://man7.org/linux/man-pages/man8/tc-tbf.8.html)'s.
+
 `[POST] /pynetem/setRules?eth=<interface name>`
-```json
+```python
 {
     "delay": "100ms 10ms 25%",
     "distribution": "normal",
@@ -46,12 +49,19 @@ Post Body, if you set parameter `None` or `''`, the parameter will be ignored.
     "loss": "0.3% 25%",
     "duplicate": "1%",
     "corrupt": "0.1%",
+    # Rate control using Netem 
+    "netem_rate": "256kbit",
+    # Rate control using TBF
     "rate": "256kbit",
     "buffer": 1600,
     "limit": 3000,
     "dst": "10.10.10.0/24"
 }
 ```
+`netem_rate` and `rate` are mutually exclusive.
+
+`buffer`, `limit`, and `dst` can only be used if `rate` is set.
+
 ---
 `[POST] /pynetem/brctl/addbr`
 

--- a/pynetem/__init__.py
+++ b/pynetem/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.4"
+__version__ = "0.1.5+snapshot"

--- a/pynetem/main.py
+++ b/pynetem/main.py
@@ -70,6 +70,13 @@ def parse_options():
     )
 
     parser.add_option(
+        '--netem-rate',
+        type='str',
+        dest='rate',
+        help="Use netem to limit trhoughput bitrate. For example: --netem-rate=256kbit",
+    )
+
+    parser.add_option(
         '--rate',
         type='str',
         dest='rate',
@@ -181,6 +188,10 @@ def main():
         logger.error('Cannot use "--reorder" without "-d"')
         sys.exit(1)
 
+    if options.rate and options.netem_rate:
+        logger.error('Cannot use "--rate" (TBF) and "--netem-rate" together')
+        sys.exit(1)
+
     if options.buffer and not options.rate:
         logger.error('Cannot use "--buffer" without "--rate"')
         sys.exit(1)
@@ -239,6 +250,8 @@ def main():
         netem['duplicate'] = options.duplicate
     if options.corrupt:
         netem['corrupt'] = options.corrupt
+    if options.netem_rate:
+        netem['rate'] = options.netem_rate
 
     if len(netem) == 0:
         logger.error('Must use netem parameters, such as delay, loss, duplicate, corrupt.')

--- a/pynetem/main.py
+++ b/pynetem/main.py
@@ -72,15 +72,22 @@ def parse_options():
     parser.add_option(
         '--netem-rate',
         type='str',
-        dest='rate',
-        help="Use netem to limit trhoughput bitrate. For example: --netem-rate=256kbit",
+        dest='netem_rate',
+        help="Use netem to limit throughput bitrate. For example: --netem-rate=256kbit",
+    )
+
+    parser.add_option(
+        '--netem-limit',
+        type='int',
+        dest='netem_limit',
+        help="Maximum number of queued packets. For example: --netem-limit=3000",
     )
 
     parser.add_option(
         '--rate',
         type='str',
         dest='rate',
-        help="Use Token Bucket Filter(TBF) to limit output. For example: --rate=256kbit",
+        help="Use Token Bucket Filter (TBF) to limit throughput bitrate. For example: --rate=256kbit",
     )
 
     parser.add_option(
@@ -252,6 +259,8 @@ def main():
         netem['corrupt'] = options.corrupt
     if options.netem_rate:
         netem['rate'] = options.netem_rate
+    if options.netem_limit:
+        netem['limit'] = options.netem_limit
 
     if len(netem) == 0:
         logger.error('Must use netem parameters, such as delay, loss, duplicate, corrupt.')

--- a/pynetem/main.py
+++ b/pynetem/main.py
@@ -260,7 +260,7 @@ def main():
     if options.netem_rate:
         netem['rate'] = options.netem_rate
     if options.netem_limit:
-        netem['limit'] = options.netem_limit
+        netem['limit'] = str(options.netem_limit)
 
     if len(netem) == 0:
         logger.error('Must use netem parameters, such as delay, loss, duplicate, corrupt.')

--- a/pynetem/pynetem.py
+++ b/pynetem/pynetem.py
@@ -59,8 +59,12 @@ class SSHAgent:
 
 
 def exec_command(command, remote_ssh=False, host=None, username=None, password=None):
+    bad_chars = ["&", "|", ";", "$", ">", "<", "`", "\\", "!"]
+    if any([char in command for char in bad_chars]):
+        return 'error', 'Illegal characters in command that may result in arbitrary execution'
+
     if not remote_ssh:
-        _exec = subprocess.Popen(command, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        _exec = subprocess.Popen(command.split(), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         info, err = _exec.communicate()
         if err:
             return 'error', err.decode('utf-8')

--- a/pynetem/web.py
+++ b/pynetem/web.py
@@ -164,7 +164,7 @@ def set_rules():
     netem['duplicate'] = duplicate
     netem['corrupt'] = corrupt
     netem['rate'] = netem_rate
-    netem['limit'] = str(netem_limit)
+    netem['limit'] = str(netem_limit) if netem_limit else None
 
     if len(netem) == 0:
         status, msg = 'error', 'Must use netem parameters, such as delay, loss, duplicate, corrupt.'

--- a/pynetem/web.py
+++ b/pynetem/web.py
@@ -64,8 +64,12 @@ def get_demo():
         'buffer': 1600,
         'limit': 3000,
         'dst': '10.10.10.0/24',
-        'description': 'This demo is just for API: [POST] /pynetem/setRules?eth=eth0.  '
-                       'If you set parameter None or \'\', the parameter will be ignored.',
+        'description':
+            'This demo is just for API: [POST] /pynetem/setRules?eth=eth0.  '
+            'If you set parameter None or \'\', the parameter will be ignored.  '
+            '"netem_rate" can also be used to control bandwidth (instead of "rate" that uses TBF).  '
+            'Format for the options can be found here: https://man7.org/linux/man-pages/man8/tc-netem.8.html.  '
+            'And for TBF rate options: https://man7.org/linux/man-pages/man8/tc-tbf.8.html',
         'otherAPIs': ['[GET/DELETE] /pynetem/clear?eth=eth0 -- clear all rules',
                       '[GET] /pynetem/listInterfaces -- list all interfaces of host']
     }
@@ -124,6 +128,7 @@ def set_rules():
     loss = data.get('loss')
     duplicate = data.get('duplicate')
     corrupt = data.get('corrupt')
+    netem_rate = data.get('netem_rate')
 
     rate = data.get('rate')
     buffer = data.get('buffer')
@@ -142,6 +147,9 @@ def set_rules():
     if reorder and not delay:
         status, msg = 'error', 'Cannot use reorder without delay'
         return status, msg, 210
+    if rate and netem_rate:
+        status, msg = 'error', 'Cannot use rate (TBF) and netem_rate together'
+        return status, msg, 210
     if not rate and (buffer or limit or cidr):
         status, msg = 'error', 'Cannot use buffer, limit or dst without rate'
         return status, msg, 210
@@ -153,6 +161,7 @@ def set_rules():
     netem['loss'] = loss
     netem['duplicate'] = duplicate
     netem['corrupt'] = corrupt
+    netem['rate'] = netem_rate
 
     if len(netem) == 0:
         status, msg = 'error', 'Must use netem parameters, such as delay, loss, duplicate, corrupt.'

--- a/pynetem/web.py
+++ b/pynetem/web.py
@@ -164,7 +164,7 @@ def set_rules():
     netem['duplicate'] = duplicate
     netem['corrupt'] = corrupt
     netem['rate'] = netem_rate
-    netem['limit'] = netem_limit
+    netem['limit'] = str(netem_limit)
 
     if len(netem) == 0:
         status, msg = 'error', 'Must use netem parameters, such as delay, loss, duplicate, corrupt.'

--- a/pynetem/web.py
+++ b/pynetem/web.py
@@ -60,6 +60,7 @@ def get_demo():
         'loss': '0.3% 25%',
         'duplicate': '1%',
         'corrupt': '0.1%',
+        'netem_limit': 3000,
         'rate': '256kbit',
         'buffer': 1600,
         'limit': 3000,
@@ -129,6 +130,7 @@ def set_rules():
     duplicate = data.get('duplicate')
     corrupt = data.get('corrupt')
     netem_rate = data.get('netem_rate')
+    netem_limit = data.get('netem_limit')
 
     rate = data.get('rate')
     buffer = data.get('buffer')
@@ -162,6 +164,7 @@ def set_rules():
     netem['duplicate'] = duplicate
     netem['corrupt'] = corrupt
     netem['rate'] = netem_rate
+    netem['limit'] = netem_limit
 
     if len(netem) == 0:
         status, msg = 'error', 'Must use netem parameters, such as delay, loss, duplicate, corrupt.'

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     keywords='',
     author='Guo Tengda',
     author_email='ttguotengda@foxmail.com',
-    url='',
+    url='https://github.com/GuoTengda1993/pynetem',
     license='MIT',
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,


### PR DESCRIPTION
Enables use of netem's native rate and limit options instead of Token Bucket Filter's (TBF)
For now, `rate` and `limit` stay mapped to the TBF command for backwards compatibility, up to you if you wish to rename them
Resolves #3
(version tag is set to 0.1.5+snapshot, I can change it to 0.1.5 if you wish for a release)