### PR TITLE
Mitigate arbitrary shell code execution

### DIFF
--- a/pynetem/__init__.py
+++ b/pynetem/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.4"
+__version__ = "0.1.5+snapshot"

--- a/pynetem/pynetem.py
+++ b/pynetem/pynetem.py
@@ -59,8 +59,12 @@ class SSHAgent:
 
 
 def exec_command(command, remote_ssh=False, host=None, username=None, password=None):
+    bad_chars = ["&", "|", ";", "$", ">", "<", "`", "\\", "!"]
+    if any([char in command for char in bad_chars]):
+        return 'error', 'Illegal characters in command that may result in arbitrary execution'
+
     if not remote_ssh:
-        _exec = subprocess.Popen(command, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        _exec = subprocess.Popen(command.split(), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         info, err = _exec.communicate()
         if err:
             return 'error', err.decode('utf-8')


### PR DESCRIPTION
Important fix!
Removed the `shell=True` from Popen because I did not see why it was there and it enables giving the command as an array.
SSH arbitrary command execution is only mitigated via a list of banned characters.
(version number has been set to `0.1.5+snapshot`)